### PR TITLE
Add condition for excluding ArgoCD Image Updater commits

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   build:
-
+    if: ${{ github.event.commits[0].author.username }} != 'argocd-image-updater'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   build:
-
+    if: ${{ github.event.commits[0].author.username }} != 'argocd-image-updater'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
ArgoCD Image Updater commits the new version of the image that is being used for updating the deployments. We need to prevent that commit from triggering a new image generation at Github Actions, otherwise we would be generating an infinite loop. What we do is to take the username of the commit for filtering those ones.