### PR TITLE
Commit-version disabled because it is failing

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,13 +66,13 @@ jobs:
           dockernexus_username: ${{ secrets.dockernexus_username }}
           dockernexus_token: ${{ secrets.dockernexus_token }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit version
-        id: commit-version
-        uses: syltek/anemone-workflows/.github/actions/commit-version@main
-        with:
-          image_version: ${{ steps.version.outputs.version }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_name: ${{ github.ref_name }}
+#      - name: Commit version
+#        id: commit-version
+#        uses: syltek/anemone-workflows/.github/actions/commit-version@main
+#        with:
+#          image_version: ${{ steps.version.outputs.version }}
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          branch_name: ${{ github.ref_name }}
 
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Getting this error ( https://github.com/syltek/anemone-weather-service/actions/runs/3515904856/jobs/5892339831 )
```

Warning: Unexpected input(s) 'if', 'commit', valid inputs are ['valueFile', 'propertyPath', 'value', 'noCompatMode', 'format', 'method', 'changes', 'branch', 'masterBranchName', 'targetBranch', 'githubAPI', 'createPR', 'commitChange', 'updateFile', 'message', 'title', 'description', 'labels', 'token', 'repository', 'workDir', 'commitUserName', 'commitUserEmail', 'reviewers', 'teamReviewers', 'assignees']
Run fjogeleit/yaml-update-action@main
Error: HttpError: Reference already exists
```