### PR TITLE
Some actions called to checkout. Super bad idea as we lose control where the checkout is done.

### DIFF
--- a/.github/actions/commit-version/action.yml
+++ b/.github/actions/commit-version/action.yml
@@ -15,12 +15,6 @@ runs:
   using: composite
 
   steps:
-    # We need fetch-depth: 0 to include the refs. 
-    # We are going to commit the version of the service in the final step.
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
     - name: Set develop environment variables
       if: ${{ inputs.branch_name == 'develop' }}
       run: |

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -31,7 +31,6 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v3
 
     - name: Set up JDK
       uses: actions/setup-java@v3

--- a/.github/actions/swarm-deploy/action.yml
+++ b/.github/actions/swarm-deploy/action.yml
@@ -30,7 +30,6 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v3
 
     - name: Set common environment variables
       run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -44,8 +44,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
+      # We need fetch-depth: 0 to include the refs. 
+      # We are going to commit the version of the service in the final step.
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build and Verify
         uses: syltek/anemone-workflows/.github/actions/maven-build@main
@@ -95,6 +98,7 @@ jobs:
       DOMAIN: 'anemone'
 
     steps:
+      - uses: actions/checkout@v3
       - uses: syltek/anemone-workflows/.github/actions/swarm-deploy@main
         with:
           version: ${{ needs.build.outputs.version }}


### PR DESCRIPTION

Now the checkout is called only in the workflows:

❯ grep checkout .github/**/*.yml
.github/workflows/build-and-deploy.yml:      - uses: actions/checkout@v3
.github/workflows/build-and-deploy.yml:      - uses: actions/checkout@v3
.github/workflows/build.yml:      - uses: actions/checkout@v3