### PR TITLE
feat: upgrade versions of actions

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.2.1
+      uses: docker/setup-buildx-action@v3
       with:
         # Use the previous version of buildx https://github.com/docker/buildx/releases
         # to solve https://github.com/docker/build-push-action/issues/761
@@ -83,7 +83,7 @@ runs:
 
     - name: Build and push
       # Fixing the version to the minor one. We used to use v2
-      uses: docker/bake-action@v2.3.0
+      uses: docker/bake-action@v4
       env:
         SERVICE_VERSION: ${{ inputs.version }}
       with:

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -67,7 +67,7 @@ runs:
       shell: bash
 
     - name: Docker login
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ env.DOCKER_USERNAME }}
@@ -75,7 +75,7 @@ runs:
 
     - name: Docker metadata
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: ${{ env.IMAGE }}
         tags: |

--- a/.github/actions/list-repos/action.yml
+++ b/.github/actions/list-repos/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Generate token
       id: generate_token
-      uses: syltek/frontend-workflows/github-app-token@main
+      uses: syltek/gh-actions/playtomic-github-app@v1
       with:
         private-key: ${{ inputs.private_key }}
 

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ inputs.java_version }}
         distribution: 'temurin'

--- a/.github/actions/swarm-deploy/action.yml
+++ b/.github/actions/swarm-deploy/action.yml
@@ -65,7 +65,7 @@ runs:
       shell: bash
 
     - name: Docker login
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ inputs.docker_registry }}
         username: ${{ inputs.docker_username }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and Verify
-        uses: syltek/anemone-workflows/.github/actions/maven-build@feat/Update_versions
+        uses: syltek/anemone-workflows/.github/actions/maven-build@main
         with:
           java_version: ${{ inputs.java_version }}
           nexus_user: ${{ secrets.nexus_user }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Extract version
         id: version
-        uses: syltek/anemone-workflows/.github/actions/anemone-version@feat/Update_versions
+        uses: syltek/anemone-workflows/.github/actions/anemone-version@main
         with:
           branch_name: ${{ github.ref_name }}
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Docker build
         id: docker-build
-        uses: syltek/anemone-workflows/.github/actions/docker-build@feat/Update_versions
+        uses: syltek/anemone-workflows/.github/actions/docker-build@main
         with:
           version: ${{ steps.version.outputs.version }}
           dockernexus_username: ${{ secrets.dockernexus_username }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Commit version
         id: commit-version
-        uses: syltek/anemone-workflows/.github/actions/commit-version@feat/Update_versions
+        uses: syltek/anemone-workflows/.github/actions/commit-version@main
         with:
           version: ${{ steps.version.outputs.version }}
           github_token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and Verify
-        uses: syltek/anemone-workflows/.github/actions/maven-build@main
+        uses: syltek/anemone-workflows/.github/actions/maven-build@feat/Update_versions
         with:
           java_version: ${{ inputs.java_version }}
           nexus_user: ${{ secrets.nexus_user }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Extract version
         id: version
-        uses: syltek/anemone-workflows/.github/actions/anemone-version@main
+        uses: syltek/anemone-workflows/.github/actions/anemone-version@feat/Update_versions
         with:
           branch_name: ${{ github.ref_name }}
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Docker build
         id: docker-build
-        uses: syltek/anemone-workflows/.github/actions/docker-build@main
+        uses: syltek/anemone-workflows/.github/actions/docker-build@feat/Update_versions
         with:
           version: ${{ steps.version.outputs.version }}
           dockernexus_username: ${{ secrets.dockernexus_username }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Commit version
         id: commit-version
-        uses: syltek/anemone-workflows/.github/actions/commit-version@main
+        uses: syltek/anemone-workflows/.github/actions/commit-version@feat/Update_versions
         with:
           version: ${{ steps.version.outputs.version }}
           github_token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # We need fetch-depth: 0 to include the refs. 
       # We are going to commit the version of the service in the final step.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             echo "branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: syltek/anemone-workflows/.github/actions/maven-build@main
+      - uses: syltek/anemone-workflows/.github/actions/maven-build@feat/Update_versions
         with:
           java_version: ${{ inputs.java_version }}
           nexus_user: ${{ secrets.nexus_user }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             echo "branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: syltek/anemone-workflows/.github/actions/maven-build@feat/Update_versions
+      - uses: syltek/anemone-workflows/.github/actions/maven-build@main
         with:
           java_version: ${{ inputs.java_version }}
           nexus_user: ${{ secrets.nexus_user }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: branch-name
         run: |


### PR DESCRIPTION
### Context
We are getting warnings in the output of our actions related to old versions of Node. I'm upgrading all the affected versions except of `whelk-io/maven-settings-xml-action` because there isn't a new version (I opened [this PR](https://github.com/whelk-io/maven-settings-xml-action/pull/163) in their repo, but it seems that it is a little bit abandoned), and `tibdex/github-app-token` that comes from the `syltek/frontend-workflows/github-app-token -> syltek/gh-actions/playtomic-github-app`.

![Screenshot 2024-02-08 at 09 52 47](https://github.com/syltek/anemone-workflows/assets/4098303/31e2bf6a-9719-4262-a38d-d3182b005394)

### Testing
- [x] Commit workflow 👉🏼  [hw-integration-service](https://github.com/syltek/anemone-hw-integrations-service/actions/runs/7827394573)
- [x] pull-request workflow 👉🏼  [hw-integrations-service](https://github.com/syltek/anemone-hw-integrations-service/actions/runs/7841575400)
- [x] deployment workflow 👉🏼  [zendesk-service](https://github.com/syltek/anemone-zendesk-service/actions/runs/7871774767)
- [x] Check that the options we use for the actions upgraded have not changed