### PR TITLE
feat: upgrade whelk-io

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -40,7 +40,7 @@ runs:
         cache: maven
 
     - name: maven-settings-xml-action
-      uses: whelk-io/maven-settings-xml-action@v21
+      uses: whelk-io/maven-settings-xml-action@v22
       with:
         servers: >
           [


### PR DESCRIPTION
### Context
We need to upgrade this action to avoid the deprecated version of Node