### PR TITLE
feat: add steps to stop the build and deploy github flow when run on a brach which is not develop or main branches

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,6 +50,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check branch name
+        id: check-branch
+        run: |
+          if [[ "${{ github.ref_name }}" =~ ^(develop|main)$ ]]; then
+            echo "Branch is develop or main."
+            echo "::set-output name=should-proceed::true"
+          else
+            echo "Branch is not develop or main. Stopping execution."
+            echo "::set-output name=should-proceed::false"
+          fi
+
+      - name: Stop if branch is not develop or main
+        if: steps.check-branch.outputs.should-proceed == 'false'
+        run: exit 1
+
       - name: Build and Verify
         uses: syltek/anemone-workflows/.github/actions/maven-build@main
         with:


### PR DESCRIPTION
CONTEXT
For time to time the automatic deployments github action fails due to github issues that we don't have control of. Recently it decided to add workflow_dispatch github action to enable manual deploy action to deployment.yml, example in payment service https://github.com/syltek/anemone-payments-service/pull/1228. 
Although the automatic deployment is limited to main and develop branch in the deployment.yml, the manual deployment not. 
In the current PR we add a condition on the job itself, to limit the built-and-deploy github action to be executed  only for main and develop branches. 

SUMMARY OF CHANGES
Add steps with the restriction on branch name a condition on the job in build-and-deploy.yml

TESTING
- [ ] Try to run the manual deployment on an existing branch. The deployment should not be executed
- [ ] Create a new branch from develop, and try to run the manual deployment on the new branch. The deployment should not be executed

ROLLBACK PLAN
This PR can be directly reverted. No rollback plan needed